### PR TITLE
Add login route with DynamoDB validation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	// Injetar o cliente no handler
 	productHandler := handlers.NewProductHandler(client, "catalog-products")
+	loginHandler := handlers.NewLoginHandler(client, "users-catalogo")
 	// auth := utils.NewAuth()
 
 	// Configurar o servidor Gin
@@ -66,6 +67,7 @@ func main() {
 	// })
 
 	// Definir as rotas GET e POST
+	router.POST("/login", loginHandler.Login)
 	router.GET("/ping", productHandler.Ping)
 	// router.GET("/api/produto/:id", productHandler.GetClientData)
 	router.GET("/api/produto/query/:query", productHandler.GetProductsQueryData)

--- a/internal/entities/user.go
+++ b/internal/entities/user.go
@@ -1,0 +1,9 @@
+package entities
+
+// User represents a user stored in DynamoDB.
+type User struct {
+	User      string `json:"user"`
+	Email     string `json:"email"`
+	Password  string `json:"password"`
+	LastLogin string `json:"Last_login"`
+}

--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"catalogo-virtual-server/internal/entities"
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/gin-gonic/gin"
+)
+
+// LoginHandler handles login requests against DynamoDB.
+type LoginHandler struct {
+	dbClient  *dynamodb.Client
+	tableName string
+}
+
+// NewLoginHandler returns a new LoginHandler.
+func NewLoginHandler(dbClient *dynamodb.Client, tableName string) *LoginHandler {
+	return &LoginHandler{dbClient: dbClient, tableName: tableName}
+}
+
+// Login verifies the credentials and updates Last_login on success.
+func (h *LoginHandler) Login(c *gin.Context) {
+	var input struct {
+		User     string `json:"user"`
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(400, gin.H{"error": "Erro ao analisar dados"})
+		return
+	}
+
+	// Retrieve the user item by User as key
+	getInput := &dynamodb.GetItemInput{
+		TableName: aws.String(h.tableName),
+		Key: map[string]types.AttributeValue{
+			"User": &types.AttributeValueMemberS{Value: input.User},
+		},
+	}
+
+	result, err := h.dbClient.GetItem(context.TODO(), getInput)
+	if err != nil {
+		log.Printf("Erro ao buscar usuario: %v", err)
+		c.JSON(500, gin.H{"error": "Erro ao buscar usuario"})
+		return
+	}
+
+	if result.Item == nil {
+		c.JSON(401, gin.H{"message": "Login invalido"})
+		return
+	}
+
+	var user entities.User
+	mapToUser(result.Item, &user)
+
+	if user.Email == input.Email && user.Password == input.Password {
+		// Update Last_login with current time
+		_, err := h.dbClient.UpdateItem(context.TODO(), &dynamodb.UpdateItemInput{
+			TableName: aws.String(h.tableName),
+			Key: map[string]types.AttributeValue{
+				"User": &types.AttributeValueMemberS{Value: input.User},
+			},
+			ExpressionAttributeNames: map[string]string{
+				"#last": "Last_login",
+			},
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":val": &types.AttributeValueMemberS{Value: time.Now().Format(time.RFC3339)},
+			},
+			UpdateExpression: aws.String("SET #last = :val"),
+		})
+		if err != nil {
+			log.Printf("Erro ao atualizar usuario: %v", err)
+			c.JSON(500, gin.H{"error": "Erro ao atualizar usuario"})
+			return
+		}
+		c.JSON(200, gin.H{"message": "Login realizado com sucesso"})
+		return
+	}
+
+	c.JSON(401, gin.H{"message": "Login invalido"})
+}
+
+// mapToUser maps DynamoDB attributes to the User struct.
+func mapToUser(item map[string]types.AttributeValue, user *entities.User) {
+	if v, ok := item["User"].(*types.AttributeValueMemberS); ok {
+		user.User = v.Value
+	}
+	if v, ok := item["Email"].(*types.AttributeValueMemberS); ok {
+		user.Email = v.Value
+	}
+	if v, ok := item["Password"].(*types.AttributeValueMemberS); ok {
+		user.Password = v.Value
+	}
+	if v, ok := item["Last_login"].(*types.AttributeValueMemberS); ok {
+		user.LastLogin = v.Value
+	}
+}


### PR DESCRIPTION
## Summary
- add `User` entity to represent credentials in DynamoDB
- implement `LoginHandler` with credential checking and last login update
- wire `/login` POST route in main

## Testing
- `go test ./...` *(fails: access to modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856ba5875b0832bb157761268d1e346