### PR TITLE
Include company name in login response

### DIFF
--- a/internal/entities/user.go
+++ b/internal/entities/user.go
@@ -5,5 +5,6 @@ type User struct {
 	User      string `json:"userId"`
 	Email     string `json:"email"`
 	Password  string `json:"password"`
+	Company   string `json:"company"`
 	LastLogin string `json:"Last_login"`
 }

--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -26,7 +26,7 @@ func NewLoginHandler(dbClient *dynamodb.Client, tableName string) *LoginHandler 
 // Login verifies the credentials and updates Last_login on success.
 func (h *LoginHandler) Login(c *gin.Context) {
 	var input struct {
-		UserId     string `json:"user"`
+		UserId   string `json:"user"`
 		Email    string `json:"email"`
 		Password string `json:"password"`
 	}
@@ -78,7 +78,7 @@ func (h *LoginHandler) Login(c *gin.Context) {
 			c.JSON(500, gin.H{"error": "Erro ao atualizar usuario"})
 			return
 		}
-		c.JSON(200, gin.H{"message": "Login realizado com sucesso"})
+		c.JSON(200, gin.H{"message": "Login realizado com sucesso", "company": user.Company})
 		return
 	}
 
@@ -95,6 +95,9 @@ func mapToUser(item map[string]types.AttributeValue, user *entities.User) {
 	}
 	if v, ok := item["Password"].(*types.AttributeValueMemberS); ok {
 		user.Password = v.Value
+	}
+	if v, ok := item["Company"].(*types.AttributeValueMemberS); ok {
+		user.Company = v.Value
 	}
 	if v, ok := item["Last_login"].(*types.AttributeValueMemberS); ok {
 		user.LastLogin = v.Value


### PR DESCRIPTION
## Summary
- add `Company` field to `User`
- expose `Company` in successful login responses

## Testing
- `go build ./...` *(fails: access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68578636b550832bbffb4abd33f28c77